### PR TITLE
Submit autoclose feature

### DIFF
--- a/public_html/templates/basic/submit.tpl
+++ b/public_html/templates/basic/submit.tpl
@@ -702,9 +702,12 @@ function rehighlight(that,check) {
 {/if}
 
 <script type="text/javascript">
+{literal}
 (function() {
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('autoclose') === 'true') {
+    const localStorageKey = 'autocloseCheckboxState';
+    const shouldAutoclose = localStorage.getItem(localStorageKey);
+
+    if (shouldAutoclose === 'true') {
         const messageDiv = document.createElement('div');
         messageDiv.textContent = 'Submission successful. This window will now close automatically in a few seconds.';
         messageDiv.style.padding = '10px';
@@ -713,9 +716,6 @@ function rehighlight(that,check) {
         messageDiv.style.textAlign = 'center';
         messageDiv.style.marginTop = '20px';
         
-        // Try to insert the message before the first h2, or append to the form
-        // More robustly, let's find the main container for step 5 content.
-        // The h2 "Submission Complete!" is a good marker.
         let insertionPoint = null;
         const h2Elements = document.getElementsByTagName('h2');
         for (let i = 0; i < h2Elements.length; i++) {
@@ -728,7 +728,6 @@ function rehighlight(that,check) {
         if (insertionPoint) {
             insertionPoint.appendChild(messageDiv);
         } else {
-            // Fallback: try to find the form and append there, or body as last resort
             const form = document.querySelector('form[name="theForm"]');
             if (form) {
                 form.appendChild(messageDiv);
@@ -742,6 +741,7 @@ function rehighlight(that,check) {
         }, 3000); // 3 second delay
     }
 })();
+{/literal}
 </script>
 {/if}
 

--- a/public_html/templates/basic/submit.tpl
+++ b/public_html/templates/basic/submit.tpl
@@ -701,6 +701,48 @@ function rehighlight(that,check) {
 	<br/><hr/><br/>
 {/if}
 
+<script type="text/javascript">
+(function() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('autoclose') === 'true') {
+        const messageDiv = document.createElement('div');
+        messageDiv.textContent = 'Submission successful. This window will now close automatically in a few seconds.';
+        messageDiv.style.padding = '10px';
+        messageDiv.style.backgroundColor = '#e6ffe6';
+        messageDiv.style.border = '1px solid #008000';
+        messageDiv.style.textAlign = 'center';
+        messageDiv.style.marginTop = '20px';
+        
+        // Try to insert the message before the first h2, or append to the form
+        // More robustly, let's find the main container for step 5 content.
+        // The h2 "Submission Complete!" is a good marker.
+        let insertionPoint = null;
+        const h2Elements = document.getElementsByTagName('h2');
+        for (let i = 0; i < h2Elements.length; i++) {
+            if (h2Elements[i].textContent.includes('Submission Complete!')) {
+                insertionPoint = h2Elements[i].parentNode;
+                break;
+            }
+        }
+
+        if (insertionPoint) {
+            insertionPoint.appendChild(messageDiv);
+        } else {
+            // Fallback: try to find the form and append there, or body as last resort
+            const form = document.querySelector('form[name="theForm"]');
+            if (form) {
+                form.appendChild(messageDiv);
+            } else {
+                document.body.insertBefore(messageDiv, document.body.firstChild);
+            }
+        }
+
+        setTimeout(function() {
+            window.close();
+        }, 3000); // 3 second delay
+    }
+})();
+</script>
 {/if}
 
 {if $step eq 6}

--- a/public_html/templates/basic/submit_multi_submit.tpl
+++ b/public_html/templates/basic/submit_multi_submit.tpl
@@ -49,7 +49,7 @@
 
 				<tr>
 					<td height="100"><a href="/submit.php?preview={$item.transfer_id}" target="_blank"><img loading="lazy" src="/submit.php?preview={$item.transfer_id}" width="160"/></a></td>
-					<td><form action="/submit.php" method="post" target="_blank" style="margin:0; background-color:lightgrey; padding:5px" onsubmit="if (document.getElementById('autoclose_checkbox').checked) { this.action = this.action + '&autoclose=true'; } return true;">
+					<td><form action="/submit.php" method="post" target="_blank" style="margin:0; background-color:lightgrey; padding:5px">
 						Subject GR: <input type="text" name="grid_reference" size="10" value="{$item.grid_reference}"/> {if $item.grid_reference}<small>{$item.grid_reference} from EXIF</small>{/if}<br/>
 						{if $item.photographer_gridref}Camera: <input type="text" name="photographer_gridref" size="10" value="{$item.photographer_gridref}"/><br/> <small style="font-size:0.7em">{$item.photographer_gridref} from EXIF</small><br/>{/if}
 
@@ -77,6 +77,7 @@
 </div>
 
 <script type="text/javascript">
+{literal}
 document.addEventListener('DOMContentLoaded', function() {
     const checkbox = document.getElementById('autoclose_checkbox');
     const localStorageKey = 'autocloseCheckboxState';
@@ -97,6 +98,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
+{/literal}
 </script>
 {literal}
 <script type="text/javascript">

--- a/public_html/templates/basic/submit_multi_submit.tpl
+++ b/public_html/templates/basic/submit_multi_submit.tpl
@@ -8,6 +8,11 @@
 
 	<h2>Multiple Image Submission</h2>
 
+	<div style="margin-bottom: 10px;">
+		<input type="checkbox" id="autoclose_checkbox">
+		<label for="autoclose_checkbox">Automatically close submission window upon successful completion.</label>
+	</div>
+
 <div style="position:relative;">
 	<div class="tabHolder">
 		<a class="tab nowrap" id="tab1" href="{$script_name}">A) Add/Upload Images</a>&nbsp;
@@ -44,7 +49,7 @@
 
 				<tr>
 					<td height="100"><a href="/submit.php?preview={$item.transfer_id}" target="_blank"><img loading="lazy" src="/submit.php?preview={$item.transfer_id}" width="160"/></a></td>
-					<td><form action="/submit.php" method="post" target="_blank" style="margin:0; background-color:lightgrey; padding:5px">
+					<td><form action="/submit.php" method="post" target="_blank" style="margin:0; background-color:lightgrey; padding:5px" onsubmit="if (document.getElementById('autoclose_checkbox').checked) { this.action = this.action + '&autoclose=true'; } return true;">
 						Subject GR: <input type="text" name="grid_reference" size="10" value="{$item.grid_reference}"/> {if $item.grid_reference}<small>{$item.grid_reference} from EXIF</small>{/if}<br/>
 						{if $item.photographer_gridref}Camera: <input type="text" name="photographer_gridref" size="10" value="{$item.photographer_gridref}"/><br/> <small style="font-size:0.7em">{$item.photographer_gridref} from EXIF</small><br/>{/if}
 
@@ -70,6 +75,29 @@
 
 	</div>
 </div>
+
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+    const checkbox = document.getElementById('autoclose_checkbox');
+    const localStorageKey = 'autocloseCheckboxState';
+
+    // On Page Load: Set checkbox state from localStorage
+    if (checkbox) {
+        const savedState = localStorage.getItem(localStorageKey);
+        if (savedState === 'true') {
+            checkbox.checked = true;
+        } else if (savedState === 'false') {
+            checkbox.checked = false;
+        }
+        // If not in localStorage, checkbox remains at its default HTML state (unchecked unless 'checked' attribute is present)
+
+        // On Checkbox Change: Save state to localStorage
+        checkbox.addEventListener('change', function() {
+            localStorage.setItem(localStorageKey, checkbox.checked.toString());
+        });
+    }
+});
+</script>
 {literal}
 <script type="text/javascript">
         function copytoall(that) {


### PR DESCRIPTION
Implement auto-close checkbox for multi-submit workflow
This change introduces an "Automatically close submission window upon
successful completion" checkbox in the multi-image submission interface
(`submit_multi_submit.tpl`).

Features:
- If checked, the single image submission window (`submit.tpl`) will
  automatically close after a successful submission (Step 5).
- The state of this checkbox is persisted in your browser's localStorage,
  so your preference is remembered across sessions.
- `submit.tpl` checks localStorage and, if present
  and true, displays a brief message and then closes the window.