### PR TITLE
Create a new page for similarity search testing

### DIFF
--- a/libs/geograph/functions.inc.php
+++ b/libs/geograph/functions.inc.php
@@ -1573,3 +1573,18 @@ function https_request_with_ip_override(string $url, string $override_ip, array 
     return file_get_contents($url, false, $context);
 }
 
+function smarty_function_votestars($params) {
+    global $CONF;
+    static $last;
+
+    $type = $params['type'];
+    $id = $params['id'];
+    $names = array('','Hmm','Below average','So So','Good','Excellent');
+    foreach (range(1,5) as $i) {
+        print "<a href=\"javascript:void(record_vote('$type',$id,$i));\" title=\"{$names[$i]}\"><img src=\"{$CONF['STATIC_HOST']}/img/star-light.png\" width=\"14\" height=\"14\" alt=\"$i\" onmouseover=\"star_hover($id,$i,5)\" onmouseout=\"star_out($id,5)\" name=\"star$i$id\"/></a>";
+    }
+    if ($last != $type) {
+        print " (<a href=\"/help/voting\">about</a>)";
+    }
+    $last = $type;
+}

--- a/libs/geograph/global.inc.php
+++ b/libs/geograph/global.inc.php
@@ -1123,6 +1123,7 @@ class GeographPage extends Smarty
 
 		//handy function for linking to getamap
 		$this->register_function("getamap", "smarty_function_getamap");
+		$this->register_function("votestars", "smarty_function_votestars");
 
 		//external site linker...
 		$this->register_function("external", "smarty_function_external");

--- a/public_html/admin/moderation.php
+++ b/public_html/admin/moderation.php
@@ -527,8 +527,6 @@ $images->assignSmarty($smarty, 'unmoderated');
 $style = $USER->getStyle();
 $smarty->assign('maincontentclass', 'content_photo'.$style);
 
-    $smarty->register_function("votestars", "smarty_function_votestars");
-
 if (!empty($_GET['full']))
 	$smarty->assign('full',1);
 
@@ -539,19 +537,4 @@ $smarty->display('admin_moderation.tpl',$style);
 
 // This tries to force the page to reload, when user presses back, mimicking the old behaviour of Cache-Control:no-store which no longer works for BFCache
 enforceNoStoreBFCache();
-
-
-
-function smarty_function_votestars($params) {
-    global $CONF;
-    static $last;
-
-    $type = $params['type'];
-    $id = $params['id'];
-    $names = array('','Hmm','Below average','So So','Good','Excellent');
-    foreach (range(1,5) as $i) {
-        print "<a href=\"javascript:void(record_vote('$type',$id,$i));\" title=\"{$names[$i]}\"><img src=\"{$CONF['STATIC_HOST']}/img/star-light.png\" width=\"14\" height=\"14\" alt=\"$i\" onmouseover=\"star_hover($id,$i,5)\" onmouseout=\"star_out($id,5)\" name=\"star$i$id\"/></a>"; 
-    }
-    $last = $type;
-}
 

--- a/public_html/editimage.php
+++ b/public_html/editimage.php
@@ -756,27 +756,8 @@ else
 
 
 
-    $smarty->register_function("votestars", "smarty_function_votestars");
-
 $smarty->display($template, $cacheid);
 
 // This tries to force the page to reload, when user presses back, mimicking the old behaviour of Cache-Control:no-store which no longer works for BFCache
 enforceNoStoreBFCache();
-
-
-function smarty_function_votestars($params) {
-    global $CONF;
-    static $last;
-
-    $type = $params['type'];
-    $id = $params['id'];
-    $names = array('','Hmm','Below average','So So','Good','Excellent');
-    foreach (range(1,5) as $i) {
-        print "<a href=\"javascript:void(record_vote('$type',$id,$i));\" title=\"{$names[$i]}\"><img src=\"{$CONF['STATIC_HOST']}/img/star-light.png\" width=\"14\" height=\"14\" alt=\"$i\" onmouseover=\"star_hover($id,$i,5)\" onmouseout=\"star_out($id,5)\" name=\"star$i$id\"/></a>";
-    }
-    if ($last != $type) {
-        print " (<a href=\"/help/voting\">about</a>)";
-    }
-    $last = $type;
-}
 

--- a/public_html/search.php
+++ b/public_html/search.php
@@ -1117,7 +1117,6 @@ if (isset($_GET['form']) && ($_GET['form'] == 'advanced' || $_GET['form'] == 'te
 			$smarty->clear_cache($template, $cacheid);
 	}
 
-	$smarty->register_function("votestars", "smarty_function_votestars");
 	if (!$smarty->is_cached($template, $cacheid)) {
 		dieUnderHighLoad(3,'search_unavailable.tpl');
 
@@ -1672,22 +1671,6 @@ if (isset($_GET['form']) && ($_GET['form'] == 'advanced' || $_GET['form'] == 'te
 
 		$smarty->display($template, $is_cachable);
 	}
-
-function smarty_function_votestars($params) {
-	global $CONF;
-	static $last;
-	
-	$type = $params['type'];
-	$id = $params['id'];
-	$names = array('','Hmm','Below average','So So','Good','Excellent');
-	foreach (range(1,5) as $i) {
-		print "<a href=\"javascript:void(record_vote('$type',$id,$i));\" title=\"{$names[$i]}\"><img src=\"{$CONF['STATIC_HOST']}/img/star-light.png\" width=\"14\" height=\"14\" alt=\"$i\" onmouseover=\"star_hover($id,$i,5)\" onmouseout=\"star_out($id,5)\" name=\"star$i$id\"/></a>";
-	}
-	if ($last != $type) {
-		print " (<a href=\"/help/voting\">about</a>)";
-	} 
-	$last = $type;
-}
 
 function smarty_function_searchbreak($params) {
 	global $engine;

--- a/public_html/stuff/tag-zeroclip-vote.php
+++ b/public_html/stuff/tag-zeroclip-vote.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * $Project: GeoGraph $
+ *
+ * GeoGraph geographic photo archive project
+ * This file copyright (C) 2024 BArry Hunter (geo@barryhunter.co.uk)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+require_once('geograph/global.inc.php');
+init_session();
+
+$smarty = new GeographPage;
+
+$smarty->assign('page_title','Tag Zero-shot CLIP Rating');
+
+$db = GeographDatabaseConnection(false);
+$ADODB_FETCH_MODE = ADODB_FETCH_ASSOC;
+
+$tagInfo = $db->getRow("select tag_id,tag from tag where prefix = 'subject' and status = 1 order by rand() limit 1");
+
+$smarty->assign('tagInfo', $tagInfo);
+
+$smarty->display('basic/stuff_tag-zeroclip-vote.tpl');

--- a/public_html/stuff/votes-rater.php
+++ b/public_html/stuff/votes-rater.php
@@ -133,7 +133,7 @@ print "<!-- $query -->\n";
 		}
 		print "</a>";
 		print "<div id=\"votediv{$image->gridimage_id}\">";
-		smarty_function_votestars(array('type'=>$type,'id'=>$row['id']));
+		$smarty->display('string:{votestars type=\''.$type.'\' id='.$row['id'].'}');
 		if (!empty($votes[$row['id']]))
 			print " (existing: {$votes[$row['id']]})</div></div>";
 		else
@@ -148,18 +148,3 @@ print "<!-- $query -->\n";
 
 
 
-function smarty_function_votestars($params) {
-	global $CONF;
-	static $last;
-	
-	$type = $params['type'];
-	$id = $params['id'];
-	$names = array('','Hmm','Below average','So So','Good','Excellent');
-	foreach (range(1,5) as $i) {
-		print "<a href=\"javascript:void(record_vote('$type',$id,$i));\" title=\"{$names[$i]}\"><img src=\"{$CONF['STATIC_HOST']}/img/star-light.png\" width=\"14\" height=\"14\" alt=\"$i\" onmouseover=\"star_hover($id,$i,5)\" onmouseout=\"star_out($id,5)\" name=\"star$i$id\"/></a>";
-	}
-	if ($last != $type) {
-		print " (<a href=\"/help/voting\">about</a>)";
-	} 
-	$last = $type;
-}

--- a/public_html/templates/basic/stuff_tag-zeroclip-vote.tpl
+++ b/public_html/templates/basic/stuff_tag-zeroclip-vote.tpl
@@ -1,0 +1,30 @@
+{include file="_std_begin.tpl"}
+
+{if $tagInfo}
+    <h2>Rate images for the tag: "{$tagInfo.tag|escape}"</h2>
+    <div id='votestars_container'>
+        {votestars type='tagzeroclip' id=$tagInfo.tag_id}
+        <a href="?" style="margin-left: 20px; padding: 5px 10px; background-color: #ddd; text-decoration: none; border: 1px solid #ccc; border-radius: 5px;">Next</a>
+    </div>
+    <div style="margin: 10px 0;">
+        <p><strong>How to vote:</strong></p>
+        <ul>
+            <li><b>1 Star</b> - not even remotely related</li>
+            <li><b>2 Stars</b> - some images getting close</li>
+            <li><b>3 Stars</b> - some images might be related, but not many</li>
+            <li><b>4 Stars</b> - mostly good images for the tag, even if not quite all</li>
+            <li><b>5 Stars</b> - very good results, all images are a strong match</li>
+        </ul>
+    </div>
+    <div id='thumbnails'></div>
+
+    <script>
+    $(function() {
+        $('#thumbnails').load('/stuff/vision-clip-query.php?inner=1&query={$tagInfo.tag|rawurlencode}');
+    });
+    </script>
+{else}
+    <p>Could not find a tag to rate.</p>
+{/if}
+
+{include file="_std_end.tpl"}


### PR DESCRIPTION
This commit introduces a new page at `public_html/stuff/tag-zeroclip-vote.php` for collecting scores to test similarity search capabilities. The page fetches a random 'subject' tag from the database, displays it with voting stars, and loads thumbnails for user assessment. It also includes a "Next" button and voting guidance.

This commit also refactors the `smarty_function_votestars` function by moving it to a central location in `libs/geograph/functions.inc.php` and registering it globally. This removes code duplication and improves maintainability.