### PR TITLE
feat: Implement 2D grid view for zero-shot search demo

### DIFF
--- a/public_html/finder/finder-demo.js
+++ b/public_html/finder/finder-demo.js
@@ -1,6 +1,7 @@
 function runSearch() {
         const query = $('#search-query').val().trim();
         const labelsStr = $('#search-labels').val().trim();
+        const groupByPlace = $('#group-by-place').is(':checked');
 
         if (!query || !labelsStr) {
             alert('Please provide both a search query and labels.');
@@ -37,7 +38,7 @@ function runSearch() {
                 // Request the vector ('image_vector') and other useful fields
                 data: {
                     [paramname]: query,
-                    select: 'id,hash,grid_reference,realname,title,image_vector',
+                    select: 'id,hash,grid_reference,realname,title,image_vector,place',
                     long: 1,
                     limit: (paramname=='match')?100:30
                 },
@@ -71,44 +72,76 @@ function runSearch() {
                 return;
             }
 
-            // 2. Group images by their nearest label
-            const groupedResults = {};
-            labels.forEach(label => {
-                groupedResults[label] = [];
-            });
-	    const unprocessed = [];
+            // 2. Group images by their nearest label (and optionally by place)
+            if (groupByPlace) {
+                const groupedResults2D = {};
+                const places = new Set();
+                const unprocessed = [];
 
-            imageResults.rows.forEach(function(image) {
-                if (image.image_vector) {
-                    try {
-                        const imageVector = new EmbeddingVector(image.image_vector).normalize();
+                labels.forEach(label => {
+                    groupedResults2D[label] = {};
+                });
 
-                        // Find the nearest label using KNN (with k=1)
-                        const nearest = imageVector.knn(labelVectors, 1);
+                imageResults.rows.forEach(function(image) {
+                    if (image.image_vector) {
+                        try {
+                            const imageVector = new EmbeddingVector(image.image_vector).normalize();
+                            const nearest = imageVector.knn(labelVectors, 1);
 
-                        if (nearest.length > 0) {
-                            const closestLabel = nearest[0].key;
-                            groupedResults[closestLabel].push(image);
+                            if (nearest.length > 0) {
+                                const closestLabel = nearest[0].key;
+                                const place = image.place || 'Unknown';
+                                places.add(place);
+
+                                if (!groupedResults2D[closestLabel][place]) {
+                                    groupedResults2D[closestLabel][place] = [];
+                                }
+                                groupedResults2D[closestLabel][place].push(image);
+                            }
+                        } catch(e) {
+                            console.error(`Could not process vector for image ID ${image.id}:`, e);
                         }
-                    } catch(e) {
-                        console.error(`Could not process vector for image ID ${image.id}:`, e);
+                    } else {
+                        unprocessed.push(image);
                     }
-                } else {
-                    unprocessed.push(image);
+                });
+
+                const sortedPlaces = Array.from(places).sort();
+                render2DResults(groupedResults2D, sortedPlaces, labels, unprocessed);
+
+            } else {
+                const groupedResults = {};
+                labels.forEach(label => {
+                    groupedResults[label] = [];
+                });
+                const unprocessed = [];
+
+                imageResults.rows.forEach(function(image) {
+                    if (image.image_vector) {
+                        try {
+                            const imageVector = new EmbeddingVector(image.image_vector).normalize();
+                            const nearest = imageVector.knn(labelVectors, 1);
+
+                            if (nearest.length > 0) {
+                                const closestLabel = nearest[0].key;
+                                groupedResults[closestLabel].push(image);
+                            }
+                        } catch(e) {
+                            console.error(`Could not process vector for image ID ${image.id}:`, e);
+                        }
+                    } else {
+                        unprocessed.push(image);
+                    }
+                });
+
+                const sortedGroups = Object.entries(groupedResults);
+                sortedGroups.sort((a, b) => b[1].length - a[1].length);
+
+                if (unprocessed.length) {
+                    sortedGroups.push(['unprocessed', unprocessed]);
                 }
-            });
-
-            const sortedGroups = Object.entries(groupedResults);
-
-            // Sort the array in descending order based on the number of images
-            sortedGroups.sort((a, b) => b[1].length - a[1].length);
-
-            if (unprocessed.length) {
-                sortedGroups.push(['unprocessed', unprocessed]);
+                render1DResults(sortedGroups);
             }
-
-            // --- Render the results (handled in the next step, but called here) ---
-            renderResults(sortedGroups);
 
         }).fail(function() {
             $resultsContainer.html('<p>An error occurred while fetching the search results. Please check the browser console for details.</p>');
@@ -120,10 +153,10 @@ function runSearch() {
 
 
     /**
-     * Renders the grouped image results into the results container.
+     * Renders the grouped image results into the results container for 1D view.
      * @param {Array} sortedResults - sorted list of labels and images
      */
-    function renderResults(sortedResults) {
+    function render1DResults(sortedResults) {
         const $resultsContainer = $('#results-container');
         $resultsContainer.empty();
 
@@ -155,6 +188,99 @@ function runSearch() {
                 $resultsContainer.append($group);
             }
         });
+    }
+
+    /**
+     * Renders the grouped image results into the results container for 2D view.
+     * @param {Object} groupedResults - The results grouped by label and then by place.
+     * @param {Array} places - An array of unique, sorted place names.
+     * @param {Array} labels - An array of the original labels.
+     * @param {Array} unprocessed - An array of images that could not be processed.
+     */
+    function render2DResults(groupedResults, places, labels, unprocessed) {
+        const $resultsContainer = $('#results-container');
+        $resultsContainer.empty();
+
+        let totalClassifiedImages = 0;
+        labels.forEach(label => {
+            places.forEach(place => {
+                if (groupedResults[label][place]) {
+                    totalClassifiedImages += groupedResults[label][place].length;
+                }
+            });
+        });
+
+        if (totalClassifiedImages === 0) {
+            $resultsContainer.html('<p>No images could be classified into places. Try a different search query or labels.</p>');
+        } else {
+            const $table = $('<table border="1" style="border-collapse: collapse; margin-top: 20px; width: 100%;"></table>');
+            const $thead = $('<thead></thead>');
+            const $tbody = $('<tbody></tbody>');
+
+            // Header row
+            const $headerRow = $('<tr></tr>');
+            $headerRow.append('<th style="width: 100px;">Label</th>');
+            places.forEach(place => {
+                $headerRow.append(`<th>${escapeHtml(place)}</th>`);
+            });
+            $thead.append($headerRow);
+
+            // Body rows
+            labels.forEach(label => {
+                const $row = $('<tr></tr>');
+                $row.append(`<td style="vertical-align: top; padding: 5px;"><b>${escapeHtml(label)}</b></td>`);
+
+                places.forEach(place => {
+                    const $cell = $('<td style="vertical-align: top; padding: 5px;"></td>');
+                    const images = groupedResults[label][place];
+
+                    if (images && images.length > 0) {
+                        const $imageContainer = $('<div class="image-container" style="flex-wrap: wrap;"></div>');
+                        images.forEach(image => {
+                            const imageUrl = getGeographUrl(image.id, image.hash, 'med');
+                            const $item = $(`
+                                <div class="image-item">
+                                    <a href="https://www.geograph.org.uk/photo/${image.id}" target="_blank" title="${image.grid_reference} ${escapeHtml(image.title)} by ${escapeHtml(image.realname)}">
+                                        <img src="${imageUrl}" alt="${escapeHtml(image.title)}" loading="lazy">
+                                    </a>
+                                </div>
+                            `);
+                            $imageContainer.append($item);
+                        });
+                        $cell.append($imageContainer);
+                    }
+                    $row.append($cell);
+                });
+                $tbody.append($row);
+            });
+
+            $table.append($thead);
+            $table.append($tbody);
+            $resultsContainer.append($table);
+        }
+
+        // Handle unprocessed images
+        if (unprocessed.length > 0) {
+            const $group = $('<div class="label-group" style="margin-top: 20px;"></div>');
+            $group.append(`<h2>Unprocessed (${unprocessed.length})</h2>`);
+
+            const $imageContainer = $('<div class="image-container"></div>');
+            unprocessed.forEach(function(image) {
+                const imageUrl = getGeographUrl(image.id, image.hash, 'med');
+                const $item = $(`
+                    <div class="image-item">
+                        <a href="https://www.geograph.org.uk/photo/${image.id}" target="_blank" title="${image.grid_reference} ${escapeHtml(image.title)} by ${escapeHtml(image.realname)}">
+                            <img src="${imageUrl}" alt="${escapeHtml(image.title)}" loading="lazy">
+                        </a>
+                        <p>${escapeHtml(image.title)}</p>
+                    </div>
+                `);
+                $imageContainer.append($item);
+            });
+
+            $group.append($imageContainer);
+            $resultsContainer.append($group);
+        }
     }
 
     /**

--- a/public_html/finder/vision-clip-zero-demo.php
+++ b/public_html/finder/vision-clip-zero-demo.php
@@ -62,6 +62,12 @@
         <label for="search-labels">Classification Labels (comma-separated):</label>
         <textarea id="search-labels" rows="3" placeholder="e.g., stone, ruin, modern, interior">stone, ruin, modern, interior</textarea>
 
+        <div class="radio-options">
+            <label>
+                <input type="checkbox" id="group-by-place" name="group-by-place" value="1">Group by place
+            </label>
+        </div>
+
         <button id="search-button">Search and Classify</button>
     </div>
 


### PR DESCRIPTION
This commit introduces a new feature to the zero-shot search demo page, allowing users to view results in a 2D grid.

The key changes are:
- A checkbox has been added to the UI, enabling users to group results by place.
- The JavaScript logic has been updated to fetch the 'place' for each image from the API.
- A new grouping mechanism classifies images by both their zeroshot label and their place.
- A new rendering function `render2DResults` has been created to display the results in a table, with labels as rows and places as columns.
- The existing 1D list view is preserved and remains the default.