### PR TITLE
feat: Add coverage dropdown to AI comparison page

### DIFF
--- a/public_html/ai/compare-pe.php
+++ b/public_html/ai/compare-pe.php
@@ -22,6 +22,14 @@ $smarty->display('_std_begin.tpl');
     <form id="queryForm" class="sidebar" onsubmit="return false;">
 	<div class="results-container">
             <div class="column">
+		<b>Coverage:</b><br>
+		<select id="coverage" name="coverage" style="width: 215px;">
+		    <option value="valeofffestiniog" selected>Vale of Ffestiniog</option>
+		    <option value="myriadsh">Myriad SH</option>
+		    <option value="national">National</option>
+		</select>
+	    </div>
+            <div class="column">
         	<b>AI Query 1:</b><br>
 	        <input type="text" name="query1" id="queryInput1" placeholder="Enter your query" style="width: 200px;">
         	<input type="submit" value="Search">
@@ -99,15 +107,32 @@ $(function() {
 
 	$('#results1, #results2').empty();
 
+        var coverage = $('#coverage').val();
+        var olbounds = null;
+
+        switch (coverage) {
+            case 'valeofffestiniog':
+                olbounds = "-4.0846952743236,52.93908175401,-3.7909739060408,53.033777228772";
+                break;
+            case 'myriadsh':
+                olbounds = "PLACEHOLDER"; // Placeholder as requested
+                break;
+            case 'national':
+                // No bounds
+                break;
+        }
+
         // --- Column 1: Standard Search ---
         var data1 = {
             long: 1,
             select: "id,user_id,realname,grid_reference,title,hash",
-	    olbounds: "-4.0846952743236,52.93908175401,-3.7909739060408,53.033777228772",
             limit: 25,
             utf: 1,
             label: query1
         };
+        if (olbounds) {
+            data1.olbounds = olbounds;
+        }
         var url1 = "/api-facetql-vector.php?" + $.param(data1);
         renderAPIResults(url1, 'results1');
 
@@ -115,12 +140,14 @@ $(function() {
         var data2 = {
             long: 1,
             select: "id,user_id,realname,grid_reference,title,hash",
-	    olbounds: "-4.0846952743236,52.93908175401,-3.7909739060408,53.033777228772",
             limit: 25,
             utf: 1,
             label: query2,
 	    model: 'pe'
         };
+        if (olbounds) {
+            data2.olbounds = olbounds;
+        }
         var url2 = "/api-facetql-vector.php?" + $.param(data2);
         renderAPIResults(url2, 'results2');
     }

--- a/public_html/ai/compare-pe.php
+++ b/public_html/ai/compare-pe.php
@@ -115,7 +115,7 @@ $(function() {
                 olbounds = "-4.0846952743236,52.93908175401,-3.7909739060408,53.033777228772";
                 break;
             case 'myriadsh':
-                olbounds = "PLACEHOLDER"; // Placeholder as requested
+                olbounds = "-4.9520110590438,52.560977841629,-3.5085777898973,53.487176816288";
                 break;
             case 'national':
                 // No bounds


### PR DESCRIPTION
Adds a dropdown menu to the AI comparison page to allow users to select different geographical coverage areas.

The `olbounds` parameter for the API calls is now dynamically set based on the selected coverage option.

The options are:
- Vale of Ffestiniog
- Myriad SH (with a placeholder value)
- National (no bounds)