### PR TITLE
Implement user-defined upload resolution in PWA

### DIFF
--- a/public_html/app/index.php
+++ b/public_html/app/index.php
@@ -62,6 +62,12 @@ function generate_import_map($dir, $basePath = '/app/js/') {
     <?= generate_import_map('/app/js/') ?>
     </script>
 
+    <script>
+        window.GEOGRAPH_USER_PREFERENCES = {
+            uploadMaxDimension: <?= json_encode($USER->upload_size ?: 65536) ?>
+        };
+    </script>
+
     <link rel="shortcut icon" type="image/x-icon" href="<? echo $CONF['STATIC_HOST']; ?>/favicon.ico">
     <link rel="manifest" href="/app/manifest.json">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">


### PR DESCRIPTION
This change enables users to define their preferred upload resolution in the PWA, mirroring the functionality on the main website.

Key changes:
1.  **Preference Defaulting:** The app now initializes `uploadMaxDimension` from the server-side `$USER->upload_size` via a global variable injected in `index.php`.
2.  **API Enhancement:** `UploadManager::setRowFromEXIF` now includes the image width and height, which are exposed via `uploads.json.php`.
3.  **Iframe Communication:** `router.js` automatically syncs the current `AppState.settings` to all persistent iframes using `postMessage` whenever they are loaded or shown.
4.  **Client-side Resizing:** `upload.php` listens for settings and triggers `resizeFileWorker` if the image dimensions exceed the preferred maximum (unless the magic 65536 value is set).
5.  **Submission Interface:** `submit.php` displays the image dimensions, warns if server-side downsizing will occur, and correctly sets the `largestsize` hidden input. The license modal now dynamically displays the final release dimensions.

---
*PR created automatically by Jules for task [9665114532855488927](https://jules.google.com/task/9665114532855488927) started by @barryhunter*