### PR TITLE
Implement user-defined upload resolution in PWA

### DIFF
--- a/libs/geograph/uploadmanager.class.php
+++ b/libs/geograph/uploadmanager.class.php
@@ -1414,6 +1414,14 @@ $this->db->raiseErrorFn = 'adodb_throw';
 
 					$row['orientation'] = $exif['IFD0']['Orientation'] ?? null;
 				}
+
+				// Also add the dimensions of the pending image (so the client knows)
+				$pending_file = $this->_pendingJPEG($row['transfer_id']);
+				if (file_exists($pending_file)) {
+					$size = getimagesize($pending_file);
+					$row['width'] = $size[0];
+					$row['height'] = $size[1];
+				}
 		return $row;
 	}
 

--- a/public_html/app/index.php
+++ b/public_html/app/index.php
@@ -62,6 +62,12 @@ function generate_import_map($dir, $basePath = '/app/js/') {
     <?= generate_import_map('/app/js/') ?>
     </script>
 
+    <script>
+        window.GEOGRAPH_USER_PREFERENCES = {
+            uploadMaxDimension: <?= json_encode($USER->upload_size ?: 65536) ?>
+        };
+    </script>
+
     <link rel="shortcut icon" type="image/x-icon" href="<? echo $CONF['STATIC_HOST']; ?>/favicon.ico">
     <link rel="manifest" href="/app/manifest.json">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">

--- a/public_html/app/js/app-state.js
+++ b/public_html/app/js/app-state.js
@@ -23,7 +23,11 @@ const AppState = {
             // Default to system preference
             const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             this.settings.darkMode = prefersDark;
-	    //todo, uploadMaxDimension needs syncing from $USER->upload_size
+
+            // Sync uploadMaxDimension from server-provided preference
+            if (window.GEOGRAPH_USER_PREFERENCES && window.GEOGRAPH_USER_PREFERENCES.uploadMaxDimension) {
+                this.settings.uploadMaxDimension = parseInt(window.GEOGRAPH_USER_PREFERENCES.uploadMaxDimension, 10);
+            }
         }
         this.syncWithDOM();
     },

--- a/public_html/app/js/router.js
+++ b/public_html/app/js/router.js
@@ -112,6 +112,10 @@ class Router {
             iframe.dataset.isTransitioning = "true";
             iframe.addEventListener('load', () => {
                 iframe.dataset.isTransitioning = "false";
+
+                // Always send the latest settings to the iframe upon load
+                iframe.contentWindow.postMessage(JSON.stringify({ settings: AppState.settings }), '*');
+
                 // Process any pending messages once loaded
                 if (iframe.dataset.pendingMessage) {
                     iframe.contentWindow.postMessage(iframe.dataset.pendingMessage, '*');
@@ -133,6 +137,11 @@ class Router {
 
         iframe.style.display = 'block';
         iframe.classList.add('active');
+
+        // Always send the latest settings to the iframe when it becomes active
+        if (iframe.dataset.isTransitioning !== 'true') {
+            iframe.contentWindow.postMessage(JSON.stringify({ settings: AppState.settings }), '*');
+        }
 
         // 2. postMessage Logic
         if (options.message) {

--- a/public_html/app/submit.php
+++ b/public_html/app/submit.php
@@ -490,6 +490,7 @@ align-items: center;    /* This centers the 350px map horizontally */
 <div id="top-boundary"></div>
 
 <div class="main-header" id="mainHeader">
+    <div id="image-dimensions" style="padding: 10px; font-weight: bold; background: #eee;"></div>
     <img id="imgLarge" class="preview-img-large" src="" alt="Full Preview">
     <div class="controls">
         <button onclick="rotateImage(270)"><span>&#8634;</span> Rotate Left</button>
@@ -512,6 +513,7 @@ align-items: center;    /* This centers the 350px map horizontally */
 
 <form method="post" name="theForm" id="theForm">
 	<input type=hidden name="upload_id" value="">
+	<input type=hidden name="largestsize" value="65536">
 
     <div style="text-align:center">
         <button type="button" onclick="openModal('map-modal')"
@@ -847,7 +849,7 @@ align-items: center;    /* This centers the 350px map horizontally */
                     This includes the <strong>metadata</strong> (location, title/description, tags, date and shared descriptions), which allows researchers and the public to 
                     discover and reuse contributions effectively.</p>
 
-                <p>You are releasing this image at [d x d] specifically, the larger size (if any) wont be released.
+                <p>You are releasing this image at <span id="final-dimensions">[d x d]</span> specifically, the larger size (if any) wont be released.
 
 	            <p><a href="/help/freedom" target="_blank">Open Geograph Freedom Manifesto</a> <span class="nowrap">(Opens in new tab)</span></p>
 
@@ -876,6 +878,7 @@ align-items: center;    /* This centers the 350px map horizontally */
 
     let upload_id = null;
 //    let update_data = [];
+    let uploadMaxDimension = 65536;
 
     window.addEventListener('message', (event) => {
         if (event.origin !== window.location.origin) return;
@@ -885,8 +888,20 @@ align-items: center;    /* This centers the 350px map horizontally */
             const data = JSON.parse(event.data);
 //            upload_data = data;
 
+            if (data.settings && data.settings.uploadMaxDimension) {
+                uploadMaxDimension = parseInt(data.settings.uploadMaxDimension, 10);
+                theForm.elements['largestsize'].value = uploadMaxDimension;
+                updateDimensionsDisplay();
+            }
+
             if (data.transfer_id)
                 resetForm(data.transfer_id);
+
+            if (data.width && data.height) {
+                currentWidth = data.width;
+                currentHeight = data.height;
+                updateDimensionsDisplay();
+            }
 
             //uploaded page will send grid_reference+photographer_gridref
             if (data.grid_reference)
@@ -970,12 +985,56 @@ align-items: center;    /* This centers the 350px map horizontally */
         window.scrollTo({top: 0}); //incase last use was scrolled!
     }
 
+    let currentWidth = 0;
+    let currentHeight = 0;
+
     function updatePreview(newId) {
         if (newId)
             upload_id = newId; //store in the global (otherwise we using from the global as is)
         theForm.elements['upload_id'].value = upload_id;
         imgLarge.src = `/submit.php?preview=${upload_id}`;
         imgThumb.src = `/submit.php?preview=${upload_id}`;
+
+        // Get dimensions from image load
+        imgLarge.onload = function() {
+            // Note: browser might show actual display dimensions, but it's a fallback
+            if (!currentWidth) {
+                currentWidth = this.naturalWidth;
+                currentHeight = this.naturalHeight;
+                updateDimensionsDisplay();
+            }
+        };
+    }
+
+    function updateDimensionsDisplay() {
+        if (!currentWidth || !currentHeight) return;
+
+        let finalWidth = currentWidth;
+        let finalHeight = currentHeight;
+        let downsized = false;
+
+        if (uploadMaxDimension < 65536 && (currentWidth > uploadMaxDimension || currentHeight > uploadMaxDimension)) {
+            const aspect = currentWidth / currentHeight;
+            if (aspect > 1) {
+                finalWidth = uploadMaxDimension;
+                finalHeight = Math.floor(uploadMaxDimension / aspect);
+            } else {
+                finalHeight = uploadMaxDimension;
+                finalWidth = Math.floor(uploadMaxDimension * aspect);
+            }
+            downsized = true;
+        }
+
+        const dimText = `${currentWidth} x ${currentHeight} pixels`;
+        const finalDimText = `${finalWidth} x ${finalHeight} pixels`;
+
+        document.getElementById('image-dimensions').innerHTML = `Current Size: ${dimText}` +
+            (downsized ? `<br><span style="color: #d9534f;">Note: This image will be downsized to ${finalDimText} server-side.</span>` : '');
+
+        const finalDimsEl = document.getElementById('final-dimensions');
+        if (finalDimsEl) {
+            finalDimsEl.textContent = finalDimText + (uploadMaxDimension >= 65536 ? ' (Full Resolution)' : '');
+        }
     }
 
 // --------------------------------

--- a/public_html/app/upload.php
+++ b/public_html/app/upload.php
@@ -19,6 +19,8 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && empty($_POST['email'])) { //aovid a
 	        $response['ok']  = $uploadmanager->processDataURL($data['image']);
         	if ($response['ok']) {
                 	$response['upload_id'] = $uploadmanager->upload_id;
+                        $response['width'] = $uploadmanager->upload_width;
+                        $response['height'] = $uploadmanager->upload_height;
 		} else {
 			$response['error'] = $uploadmanager->errormsg;
 		}
@@ -138,6 +140,20 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && empty($_POST['email'])) { //aovid a
 
     let fileQueue = [];
     const max_size = 8 * 1024 * 1024; //larger files will be downsized!
+    let uploadMaxDimension = 65536; // Default to effectively unlimited
+
+    window.addEventListener('message', (event) => {
+        if (event.origin !== window.location.origin) return;
+        try {
+            const data = JSON.parse(event.data);
+            if (data.settings && data.settings.uploadMaxDimension) {
+                uploadMaxDimension = parseInt(data.settings.uploadMaxDimension, 10);
+                console.log('Updated uploadMaxDimension to:', uploadMaxDimension);
+            }
+        } catch (e) {
+            // Not JSON or other message type
+        }
+    });
 
     // Persist Preference
     autoProceedCheck.checked = localStorage.getItem('autoProceed') === 'true';
@@ -178,13 +194,35 @@ if ($_SERVER["REQUEST_METHOD"] === "POST" && empty($_POST['email'])) { //aovid a
         }));
 
         // 2. Resize if necessary
-        let dataUri = await new Promise(resolve => {
-            if (item.file.size > max_size && !isHeic) {
+        let dataUri = await new Promise(async (resolve) => {
+            let needsResize = (item.file.size > max_size);
+
+            if (!needsResize && uploadMaxDimension < 65536) {
+                // Also check dimensions
+                const dimensions = await new Promise(res => {
+                    const img = new Image();
+                    img.onload = () => {
+                        const dims = {w: img.width, h: img.height};
+                        URL.revokeObjectURL(img.src);
+                        res(dims);
+                    };
+                    img.onerror = () => {
+                        URL.revokeObjectURL(img.src);
+                        res(null);
+                    };
+                    img.src = URL.createObjectURL(item.file);
+                });
+                if (dimensions && (dimensions.w > uploadMaxDimension || dimensions.h > uploadMaxDimension)) {
+                    needsResize = true;
+                }
+            }
+
+            if (needsResize && !isHeic) {
                 resizeFileWorker(item.file, max_size, (url) => {
                     const finished = document.getElementById('messageDiv');
                     if (finished) finished.remove();
                     resolve(url);
-                });
+                }, uploadMaxDimension);
             } else {
                 const reader = new FileReader();
                 reader.onload = (e) => resolve(e.target.result);
@@ -280,16 +318,16 @@ async function renderUI() {
 
             // Sequential POST request
             const result = await sendToPHP(item.dataUri);
-            if (result) {
+            if (result && result.success) {
                 // SUCCESS: Remove from queue and mark visually
                 document.getElementById(`wrapper-${item.id}`).classList.add('uploaded');
 		// Add the UploadID to buttons
 		if (i == 0 && fileQueue.length == 1) {
-			addIdtoBtn('btnSingle', result.upload_id);
+			addIdtoBtn('btnSingle', result.upload_id, result.width, result.height);
 		} else if (i == 0) {
-			addIdtoBtn('btnFirst', result.upload_id);
+			addIdtoBtn('btnFirst', result.upload_id, result.width, result.height);
 		} else if (i == fileQueue.length-1) {
-			addIdtoBtn('btnLast', result.upload_id);
+			addIdtoBtn('btnLast', result.upload_id, result.width, result.height);
 		}
 		upload_id = result.upload_id;
                 // Remove from array so it's gone if we click upload again
@@ -311,7 +349,7 @@ async function renderUI() {
             selectLabel.style.opacity = 0.7;
             uploadBtn.classList.add('hidden');
             if (fileQueueLength === 1 && autoProceedCheck.checked && document.visibilityState === 'visible') {
-                navigateTo('/app/submit',{message: 'transfer_id='+upload_id});
+                navigateTo('/app/submit',{message: JSON.stringify({transfer_id: upload_id, width: result.width, height: result.height})});
 	        postActions.classList.add('hidden');
   	        displayArea.innerHTML = '';
             } else {
@@ -325,25 +363,10 @@ async function renderUI() {
         }
     };
 
-function addIdtoBtn(btnId, upload_id) {
+function addIdtoBtn(btnId, upload_id, width, height) {
 	//want to overite any existing click (from a previous call!)
         document.getElementById(btnId).onclick = function() {
-
-/* TODO actully we going to have to provide (or we could send lat/long direcltyl!)
- {
-        "transfer_id": "2f24bc8f3ce8c249bff61564d09022ed",
-        "photographer_gridref": "TQ3840294942",
-        "grid_reference": "TQ3894",
-        "imagetaken": "2024-12-14 15:01:02",
-        "orientation": 1
- }
-
-          const itemString = JSON.stringify(item);
-
-*/
-
-
-		navigateTo('/app/submit',{message: 'transfer_id='+upload_id});
+		navigateTo('/app/submit',{message: JSON.stringify({transfer_id: upload_id, width: width, height: height})});
 		postActions.classList.add('hidden');
 		displayArea.innerHTML = '';
 	};
@@ -383,7 +406,7 @@ async function sendToPHP(dataUri) {
         // 3. Handle your custom application-level success/error
         if (result.ok) {
             console.log('Upload successful! ID:', result.upload_id);
-            return { success: true, upload_id: result.upload_id };
+            return { success: true, upload_id: result.upload_id, width: result.width, height: result.height };
         } else {
             console.error('Upload failed:', result.error);
             return { success: false, error: result.error };


### PR DESCRIPTION
This change enables users to define their preferred upload resolution in the PWA, mirroring the functionality on the main website.

Key changes:
1.  **Preference Defaulting:** The app now initializes `uploadMaxDimension` from the server-side `$USER->upload_size` via a global variable injected in `index.php`.
2.  **API Enhancement:** `UploadManager::setRowFromEXIF` now includes the image width and height, which are exposed via `uploads.json.php`.
3.  **Iframe Communication:** `router.js` automatically syncs the current `AppState.settings` to all persistent iframes using `postMessage` whenever they are loaded or shown.
4.  **Client-side Resizing:** `upload.php` listens for settings and triggers `resizeFileWorker` if the image dimensions exceed the preferred maximum (unless the magic 65536 value is set).
5.  **Submission Interface:** `submit.php` displays the image dimensions, warns if server-side downsizing will occur, and correctly sets the `largestsize` hidden input. The license modal now dynamically displays the final release dimensions.

---
*PR created automatically by Jules for task [9665114532855488927](https://jules.google.com/task/9665114532855488927) started by @barryhunter*