### PR TITLE
Add "Create New Shared Description" modal to submission page

### DIFF
--- a/public_html/app/submit.php
+++ b/public_html/app/submit.php
@@ -1148,7 +1148,34 @@ function toggleLock() {
         </div>
 
 	  <button type="button" onclick="openModal('tag-modal')" class="help-link">What do all these fields mean? &#9432;</button>
+	  <button type="button" onclick="openCreateSnippetModal()" class="btn btn-secondary" style="width: auto; display: inline-block; margin: 0 0 0 10px; padding: 10px 20px;">Create New Shared Description</button>
 
+
+<dialog id="create-snippet-modal">
+    <div style="max-height: 80vh; overflow-y: auto; padding: 10px;">
+        <h3>Create New Shared Description</h3>
+        <form id="create-snippet-form">
+            <label for="snippet-title">Title</label>
+            <input type="text" id="snippet-title" name="title" maxlength="64" required placeholder="Short descriptive title">
+
+            <label for="snippet-comment">Description</label>
+            <textarea id="snippet-comment" name="comment" maxlength="16384" required rows="5" placeholder="Detailed description..."></textarea>
+
+            <label for="snippet-gridref">Grid Reference</label>
+            <input type="text" id="snippet-gridref" name="grid_reference" pattern="^[A-Za-z]{1,2}\s*\d{1,5}\s*\d{1,5}$" placeholder="e.g. TQ 123 456">
+
+            <label class="flag-item" for="snippet-nogr">
+                <input type="checkbox" id="snippet-nogr" name="nogr" value="1" onchange="toggleSnippetGridRef(this.checked)">
+                <span><b>Do not Attach Location</b></span>
+            </label>
+
+            <div style="display: flex; gap: 10px; margin-top: 20px;">
+                <button type="submit" class="btn btn-primary" style="flex: 1;">Create</button>
+                <button type="button" onclick="closeModal('create-snippet-modal')" class="btn btn-secondary" style="flex: 1;">Cancel</button>
+            </div>
+        </form>
+    </div>
+</dialog>
 
 <dialog id="tag-modal" onclick="closeModal('tag-modal')">
     <div style="max-height: 80vh; overflow-y: auto; padding: 10px;">
@@ -1508,6 +1535,44 @@ function toggleLock() {
 	window.openModal = openModal;
 	window.closeModal = closeModal;
 	window.updateAppState = updateAppState;
+
+    window.openCreateSnippetModal = function() {
+        const mainGR = document.getElementById('grid_reference').value;
+        document.getElementById('snippet-gridref').value = mainGR;
+        document.getElementById('snippet-gridref').disabled = false;
+        document.getElementById('snippet-nogr').checked = false;
+        document.getElementById('create-snippet-form').reset();
+        document.getElementById('snippet-gridref').value = mainGR; // Reset clears it, so set again
+        openModal('create-snippet-modal');
+    };
+
+    window.toggleSnippetGridRef = function(nogr) {
+        document.getElementById('snippet-gridref').disabled = nogr;
+    };
+
+    document.getElementById('create-snippet-form').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        formData.append('create', 'true');
+
+        try {
+            const response = await fetch('/submit_snippet.php?json=1', {
+                method: 'POST',
+                body: formData
+            });
+            if (!response.ok) throw new Error('Network response was not ok');
+            const result = await response.json();
+            if (result.error) {
+                alert('Error: ' + result.error);
+            } else {
+                addSnippet(result.id, result.title);
+                closeModal('create-snippet-modal');
+            }
+        } catch (error) {
+            console.error('Error creating snippet:', error);
+            alert('Failed to create shared description. Please try again.');
+        }
+    });
 </script>
 
 <script src="<? echo smarty_modifier_revision("/app/js/used-nearby.libs.js"); ?>"></script>

--- a/public_html/submit_snippet.php
+++ b/public_html/submit_snippet.php
@@ -113,6 +113,7 @@ if (!empty($_POST['create']) && (!empty($_POST['title']) || !empty($_POST['comme
 	}
 
 	$db->Execute('INSERT INTO snippet SET created=NOW(),point_en=GeomFromText('.$point.'),`'.implode('` = ?,`',array_keys($updates)).'` = ?',array_values($updates));
+	$new_snippet_id = $db->Insert_ID();
 
 	if ($gid) {
 		$updates = array();
@@ -135,6 +136,15 @@ if (!empty($_POST['create']) && (!empty($_POST['title']) || !empty($_POST['comme
 	}
 
 	split_timer('snippet','create',$gid); //logs the wall time
+
+	if (!empty($_GET['json'])) {
+		header('Content-Type: application/json');
+		echo json_encode(array(
+			'id' => $new_snippet_id,
+			'title' => $_POST['title']
+		));
+		exit;
+	}
 
 ################################################
 


### PR DESCRIPTION
Implemented a new feature in `public_html/app/submit.php` that allows users to create a new "Shared Description" (snippet) directly from the image submission page. 

Key changes:
1.  **Backend (`public_html/submit_snippet.php`)**: Updated the creation logic to support a `json=1` parameter. When present, it returns a JSON object with the new snippet's ID and title. Added a fix to ensure the correct ID is captured before any secondary database operations (like timers).
2.  **Frontend (`public_html/app/submit.php`)**:
    *   Added a "Create New Shared Description" button next to the existing help link.
    *   Implemented a modal dialog using the native `<dialog>` element.
    *   Included fields for Title, Description, and Grid Reference.
    *   The Grid Reference field is prefilled from the main form's subject location.
    *   Added a "Do not Attach Location" checkbox that toggles the Grid Reference input.
    *   Implemented AJAX submission to the updated backend endpoint.
    *   On success, the new snippet is automatically added to the image's snippets list using the existing `addSnippet` function, and the modal is closed.
3.  **Validation**: Verified the changes via PHP linting and static code analysis.

---
*PR created automatically by Jules for task [16463892113441796317](https://jules.google.com/task/16463892113441796317) started by @barryhunter*