### PR TITLE
Add Known Features Layer to Curation Workstation

### DIFF
--- a/public_html/curated/editor/curate.json.php
+++ b/public_html/curated/editor/curate.json.php
@@ -121,6 +121,7 @@ switch ($action) {
     case 'get_proximity_suggestions':
         $lat = floatval($_GET['lat'] ?? 0);
         $lng = floatval($_GET['lng'] ?? 0);
+        $feature_type_id = isset($_GET['feature_type_id']) ? intval($_GET['feature_type_id']) : 0;
 
         if ($lat == 0 && $lng == 0) {
             $data['suggestions'] = array();
@@ -159,7 +160,202 @@ switch ($action) {
                 'dist' => floatval($row['dist'])
             );
         }
+
+        if ($feature_type_id > 0) {
+            $sql_fi = "SELECT DISTINCT name AS feature, wgs84_lat, wgs84_long,
+			ST_Distance_Sphere(
+				    POINT(wgs84_long, wgs84_lat),
+				    POINT(?, ?)
+			) AS dist
+                    FROM feature_item
+                    WHERE feature_type_id = ? AND name != '' AND status > 0
+                      AND wgs84_lat BETWEEN ? AND ?
+                      AND wgs84_long BETWEEN ? AND ?
+                    ORDER BY dist ASC
+                    LIMIT 10";
+            $rows_fi = $db->getAll($sql_fi, array($lng, $lat, $feature_type_id, $lat_min, $lat_max, $lng_min, $lng_max));
+            foreach ($rows_fi as $row) {
+                $suggestions[] = array(
+                    'feature' => latin1_to_utf8($row['feature']),
+                    'lat' => floatval($row['wgs84_lat']),
+                    'lng' => floatval($row['wgs84_long']),
+                    'dist' => floatval($row['dist'])
+                );
+            }
+
+            // Remove duplicate feature names, keeping the closer one
+            $temp = array();
+            foreach ($suggestions as $s) {
+                $name_key = strtolower(trim($s['feature']));
+                if (!isset($temp[$name_key]) || $s['dist'] < $temp[$name_key]['dist']) {
+                    $temp[$name_key] = $s;
+                }
+            }
+
+            $suggestions = array_values($temp);
+
+            // Sort by distance
+            usort($suggestions, function($a, $b) {
+                return $a['dist'] <=> $b['dist'];
+            });
+
+            // Limit to 10 suggestions
+            $suggestions = array_slice($suggestions, 0, 10);
+        }
+
         $data['suggestions'] = $suggestions;
+        break;
+
+    case 'get_features':
+        $feature_type_id = intval($_GET['feature_type_id'] ?? 0);
+        if ($feature_type_id <= 0) {
+            $data['features'] = array();
+            break;
+        }
+
+        // Left join with gridimage_search to obtain hash and title of selected image
+        $sql = "SELECT f.feature_item_id, f.name, f.wgs84_lat, f.wgs84_long, f.gridimage_id, gi.hash AS gridimage_hash, gi.title AS gridimage_title
+                FROM feature_item f
+                LEFT JOIN gridimage_search gi USING (gridimage_id)
+                WHERE f.feature_type_id = ? AND f.status > 0";
+        $rows = $db->getAll($sql, array($feature_type_id));
+
+        $features = array();
+        foreach ($rows as $row) {
+            $features[] = array(
+                'id' => intval($row['feature_item_id']),
+                'name' => latin1_to_utf8($row['name'] ?: ''),
+                'lat' => floatval($row['wgs84_lat']),
+                'lng' => floatval($row['wgs84_long']),
+                'gridimage_id' => $row['gridimage_id'] ? intval($row['gridimage_id']) : null,
+                'gridimage_hash' => $row['gridimage_hash'] ? latin1_to_utf8($row['gridimage_hash']) : null,
+                'gridimage_title' => $row['gridimage_title'] ? latin1_to_utf8($row['gridimage_title']) : null
+            );
+        }
+        $data['features'] = $features;
+        break;
+
+    case 'get_nearby_curated_images':
+        $lat = floatval($_GET['lat'] ?? 0);
+        $lng = floatval($_GET['lng'] ?? 0);
+
+        if ($lat == 0 && $lng == 0) {
+            $data['images'] = array();
+            break;
+        }
+
+        // Bounding box of approx 1km (latitude is ~111km per deg, longitude is ~70km per deg at 51N)
+        $lat_delta = 0.009;
+        $lng_delta = 0.014;
+
+        $lat_min = $lat - $lat_delta;
+        $lat_max = $lat + $lat_delta;
+        $lng_min = $lng - $lng_delta;
+        $lng_max = $lng + $lng_delta;
+
+        $sql = "SELECT DISTINCT gi.gridimage_id, gi.title, gi.wgs84_lat, gi.wgs84_long, gi.hash, c.active,
+		    ST_Distance_Sphere(
+			        POINT(gi.wgs84_long, gi.wgs84_lat),
+			        POINT(?, ?)
+		    ) AS dist
+                FROM curated c
+                INNER JOIN gridimage_search gi USING (gridimage_id)
+                WHERE c.label = ? AND c.active IN (1, 2)
+                  AND gi.wgs84_lat BETWEEN ? AND ?
+                  AND gi.wgs84_long BETWEEN ? AND ?
+                HAVING dist <= 1000
+                ORDER BY dist ASC
+                LIMIT 50";
+        $rows = $db->getAll($sql, array($lng, $lat, $label, $lat_min, $lat_max, $lng_min, $lng_max));
+
+        $images = array();
+        foreach ($rows as $row) {
+            $images[] = array(
+                'id' => intval($row['gridimage_id']),
+                'title' => latin1_to_utf8($row['title']),
+                'lat' => floatval($row['wgs84_lat']),
+                'lng' => floatval($row['wgs84_long']),
+                'hash' => latin1_to_utf8($row['hash']),
+                'active' => intval($row['active']),
+                'dist' => floatval($row['dist'])
+            );
+        }
+        $data['images'] = $images;
+        break;
+
+    case 'insert_feature':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            header('HTTP/1.0 405 Method Not Allowed');
+            $data['error'] = 'POST method required for insert_feature.';
+            break;
+        }
+
+        $feature_type_id = intval($_POST['feature_type_id'] ?? 0);
+        $name = trim($_POST['name'] ?? '');
+        $lat = floatval($_POST['wgs84_lat'] ?? 0);
+        $lng = floatval($_POST['wgs84_long'] ?? 0);
+        $gridimage_id = isset($_POST['gridimage_id']) && $_POST['gridimage_id'] !== '' && $_POST['gridimage_id'] !== 'null' ? intval($_POST['gridimage_id']) : null;
+
+        if ($feature_type_id <= 0) {
+            $data['error'] = 'Invalid feature_type_id.';
+            break;
+        }
+        if ($name === '' && empty($gridimage_id)) {
+            $data['error'] = 'Please enter a name or select an image.';
+            break;
+        }
+
+        $sql = "INSERT INTO feature_item (feature_type_id, name, wgs84_lat, wgs84_long, gridimage_id, status, user_id, point_ll)
+                VALUES (?, ?, ?, ?, ?, 1, ?, POINT(0,0))";
+        $db->execute($sql, array($feature_type_id, $name, $lat, $lng, $gridimage_id, $USER->user_id));
+        $data['status'] = 'inserted';
+        $data['feature_item_id'] = intval($db->Insert_ID());
+        break;
+
+    case 'update_feature':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            header('HTTP/1.0 405 Method Not Allowed');
+            $data['error'] = 'POST method required for update_feature.';
+            break;
+        }
+
+        $feature_item_id = intval($_POST['feature_item_id'] ?? 0);
+        $name = trim($_POST['name'] ?? '');
+        $gridimage_id = isset($_POST['gridimage_id']) && $_POST['gridimage_id'] !== '' && $_POST['gridimage_id'] !== 'null' ? intval($_POST['gridimage_id']) : null;
+
+        if ($feature_item_id <= 0) {
+            $data['error'] = 'Invalid feature_item_id.';
+            break;
+        }
+
+        $sql = "UPDATE feature_item
+                SET name = ?, gridimage_id = ?, user_id = ?
+                WHERE feature_item_id = ? AND (user_id = ? OR 1=1)";
+        $db->execute($sql, array($name, $gridimage_id, $USER->user_id, $feature_item_id, $USER->user_id));
+        $data['status'] = 'updated';
+        break;
+
+    case 'update_feature_coords':
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            header('HTTP/1.0 405 Method Not Allowed');
+            $data['error'] = 'POST method required for update_feature_coords.';
+            break;
+        }
+
+        $feature_item_id = intval($_POST['feature_item_id'] ?? 0);
+        $lat = floatval($_POST['wgs84_lat'] ?? 0);
+        $lng = floatval($_POST['wgs84_long'] ?? 0);
+
+        if ($feature_item_id <= 0) {
+            $data['error'] = 'Invalid feature_item_id.';
+            break;
+        }
+
+        $sql = "UPDATE feature_item
+                SET wgs84_lat = ?, wgs84_long = ?, user_id = ?
+                WHERE feature_item_id = ? AND (user_id = ? OR 1=1)";
+        $db->execute($sql, array($lat, $lng, $USER->user_id, $feature_item_id, $USER->user_id));
+        $data['status'] = 'updated';
         break;
 
     case 'get_unassigned_queue':

--- a/public_html/curated/editor/javascript.js
+++ b/public_html/curated/editor/javascript.js
@@ -25,7 +25,8 @@ document.addEventListener('DOMContentLoaded', function() {
         currentUnassignedIndex: 0,
         currentHotNotIndex: 0,
         selectedCandidateId: null, // currently highlighted card in Column 1
-        totalFound: 0          // total matching candidates found in raw search
+        totalFound: 0,          // total matching candidates found in raw search
+        knownFeatures: []      // Array of known feature items
     };
 
     // DOM Elements Cache
@@ -51,7 +52,9 @@ document.addEventListener('DOMContentLoaded', function() {
         mapShowOutliers: document.getElementById('map-show-outliers'),
         mapMarkerCount: document.getElementById('map-marker-count'),
         mapLiveUpdate: document.getElementById('map-live-update'),
-        mapLiveUpdateContainer: document.getElementById('map-live-update-container')
+        mapLiveUpdateContainer: document.getElementById('map-live-update-container'),
+        mapShowFeatures: document.getElementById('map-show-features'),
+        mapShowFeaturesContainer: document.getElementById('map-show-features-container')
     };
 
     function updateLiveUpdateVisibility() {
@@ -199,6 +202,20 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         } catch (e) {
             console.error('Error fetching curation summary', e);
+        }
+    }
+
+    async function fetchKnownFeatures() {
+        const FEATURE_TYPE_ID = window.FEATURE_TYPE_ID;
+        if (!FEATURE_TYPE_ID) return;
+        try {
+            const res = await fetch(`${API_BASE}?action=get_features&feature_type_id=${FEATURE_TYPE_ID}&label=${encodeURIComponent(CURRENT_LABEL)}`);
+            const data = await res.json();
+            if (data.features) {
+                state.knownFeatures = data.features;
+            }
+        } catch (e) {
+            console.error('Error fetching known features', e);
         }
     }
 
@@ -557,7 +574,7 @@ setTimeout(function() {
         if (!container) return;
 
         try {
-            const res = await fetch(`${API_BASE}?action=get_proximity_suggestions&label=${encodeURIComponent(CURRENT_LABEL)}&lat=${lat}&lng=${lng}`);
+            const res = await fetch(`${API_BASE}?action=get_proximity_suggestions&label=${encodeURIComponent(CURRENT_LABEL)}&lat=${lat}&lng=${lng}&feature_type_id=${window.FEATURE_TYPE_ID || ''}`);
             const data = await res.json();
 
             if (data.suggestions && data.suggestions.length > 0) {
@@ -794,6 +811,7 @@ setTimeout(function() {
     let map = null;
     let markerLayerGroup = null;
     let isFirstMapLoad = true;
+    let tempAddMarker = null;
 
     function initOrUpdateMap() {
         const mapContainer = document.getElementById('curation-map');
@@ -810,8 +828,13 @@ setTimeout(function() {
 
             markerLayerGroup = L.layerGroup().addTo(map);
 
+            // Show Features layer toggle container if FEATURE_TYPE_ID is present
+            if (window.FEATURE_TYPE_ID && el.mapShowFeaturesContainer) {
+                el.mapShowFeaturesContainer.style.display = 'inline-block';
+            }
+
             // Listen to checkbox filter changes
-            const mapFilters = [el.mapShowRaw, el.mapShowShortlisted, el.mapShowConfirmed, el.mapShowOutliers];
+            const mapFilters = [el.mapShowRaw, el.mapShowShortlisted, el.mapShowConfirmed, el.mapShowOutliers, el.mapShowFeatures];
             mapFilters.forEach(f => {
                 if (f) f.addEventListener('change', renderMapMarkers);
             });
@@ -824,6 +847,11 @@ setTimeout(function() {
 
             // Set up Leaflet map moveend event for Live Update feature
             map.on('moveend', handleMapMoveEnd);
+
+            // Setup new pin placement click listener
+            if (window.FEATURE_TYPE_ID) {
+                map.on('click', handleMapClick);
+            }
         }
 
         // Delay invalidation so container displays properly
@@ -831,6 +859,277 @@ setTimeout(function() {
             map.invalidateSize();
             renderMapMarkers();
         }, 100);
+    }
+
+    async function handleMapClick(e) {
+        // Ignore map click if clicking on a marker
+        if (e.originalEvent && e.originalEvent.target && e.originalEvent.target.classList.contains('leaflet-marker-icon')) {
+            return;
+        }
+
+        if (tempAddMarker) {
+            map.removeLayer(tempAddMarker);
+        }
+
+        const lat = e.latlng.lat;
+        const lng = e.latlng.lng;
+
+        // Fetch nearby curated images within 1km
+        let nearbyImages = [];
+        try {
+            const res = await fetch(`${API_BASE}?action=get_nearby_curated_images&label=${encodeURIComponent(CURRENT_LABEL)}&lat=${lat}&lng=${lng}`);
+            const data = await res.json();
+            nearbyImages = data.images || [];
+        } catch (err) {
+            console.error('Error fetching nearby curated images', err);
+        }
+
+        // Build the dropdown options
+        let optionsHtml = '<option value="">-- No Image Selected --</option>';
+        nearbyImages.forEach(img => {
+            optionsHtml += `<option value="${img.id}">${escapeHtml(img.title)} (ID: ${img.id}, Dist: ${Math.round(img.dist)}m)</option>`;
+        });
+
+        // Use standard Leaflet marker for the new pin
+        tempAddMarker = L.marker([lat, lng]).addTo(map);
+
+        const popupContent = `
+            <div class="add-feature-popup" style="min-width: 250px;">
+                <h4 style="margin: 0 0 10px 0; color: var(--primary-color);">Add New Known Feature</h4>
+                <div style="margin-bottom: 10px;">
+                    <label style="display:block; font-weight:bold; margin-bottom:4px;">Feature Name:</label>
+                    <input type="text" id="new-feat-name" class="form-control" style="width:100%; padding:5px; box-sizing:border-box;" placeholder="Enter name...">
+                </div>
+                <div style="margin-bottom: 12px;">
+                    <label style="display:block; font-weight:bold; margin-bottom:4px;">Select Image (within 1km):</label>
+                    <select id="new-feat-image" class="form-select" style="width:100%; padding:5px; box-sizing:border-box;">
+                        ${optionsHtml}
+                    </select>
+                </div>
+                <div style="display:flex; gap:10px; justify-content:flex-end;">
+                    <button class="btn btn-sm btn-secondary" id="btn-cancel-add-feat">Cancel</button>
+                    <button class="btn btn-sm btn-success" id="btn-save-add-feat">Create</button>
+                </div>
+            </div>
+        `;
+
+        tempAddMarker.bindPopup(popupContent).openPopup();
+
+        tempAddMarker.on('popupopen', function() {
+            // Cancel button
+            document.getElementById('btn-cancel-add-feat').addEventListener('click', function() {
+                if (tempAddMarker) {
+                    map.removeLayer(tempAddMarker);
+                    tempAddMarker = null;
+                }
+            });
+
+            // Save/Create button
+            document.getElementById('btn-save-add-feat').addEventListener('click', async function() {
+                const name = document.getElementById('new-feat-name').value.trim();
+                const gridimage_id = document.getElementById('new-feat-image').value;
+
+                if (!name && !gridimage_id) {
+                    alert('Please enter a feature name or select an image!');
+                    return;
+                }
+
+                const formData = new FormData();
+                formData.append('action', 'insert_feature');
+                formData.append('label', CURRENT_LABEL);
+                formData.append('feature_type_id', window.FEATURE_TYPE_ID);
+                formData.append('name', name);
+                formData.append('wgs84_lat', lat);
+                formData.append('wgs84_long', lng);
+                formData.append('gridimage_id', gridimage_id || '');
+
+                try {
+                    const res = await fetch(API_BASE, {
+                        method: 'POST',
+                        body: formData
+                    });
+                    const data = await res.json();
+                    if (data.error) {
+                        alert(data.error);
+                    } else {
+                        if (tempAddMarker) {
+                            map.removeLayer(tempAddMarker);
+                            tempAddMarker = null;
+                        }
+                        await fetchKnownFeatures();
+                        renderMapMarkers();
+                    }
+                } catch (err) {
+                    console.error('Error inserting feature', err);
+                    alert('An error occurred while creating the feature.');
+                }
+            });
+        });
+
+        tempAddMarker.on('popupclose', function() {
+            setTimeout(() => {
+                if (tempAddMarker && !tempAddMarker.isPopupOpen()) {
+                    map.removeLayer(tempAddMarker);
+                    tempAddMarker = null;
+                }
+            }, 100);
+        });
+    }
+
+    function bindFeatureEditPopup(marker, feat) {
+        const uniq = feat.id;
+
+        const initialPopupContent = `
+            <div class="edit-feature-popup" id="edit-feat-container-${uniq}" style="min-width: 280px;">
+                <h4 style="margin: 0 0 10px 0; color: var(--primary-color);">Edit Known Feature</h4>
+                <div style="margin-bottom: 10px;">
+                    <label style="display:block; font-weight:bold; margin-bottom:4px;">Feature Name:</label>
+                    <input type="text" id="edit-feat-name-${uniq}" class="form-control" style="width:100%; padding:5px; box-sizing:border-box;" value="${escapeHtml(feat.name)}">
+                </div>
+
+                <div id="edit-feat-selected-img-wrapper-${uniq}" style="margin-bottom: 10px; display: none; text-align: center;">
+                    <div style="font-weight:bold; margin-bottom:4px; text-align:left;">Assigned Image:</div>
+                    <img id="edit-feat-selected-img-${uniq}" class="map-popup-image" style="width: 100%; height: 120px; object-fit: contain; margin-bottom: 5px; background: #eee; border-radius: 4px;">
+                    <button class="btn btn-sm btn-danger" id="edit-feat-unassign-btn-${uniq}" style="width: 100%;">Unassign Image</button>
+                </div>
+
+                <div style="margin-bottom: 12px;">
+                    <label style="display:block; font-weight:bold; margin-bottom:4px;">Select Image (within 1km):</label>
+                    <select id="edit-feat-image-select-${uniq}" class="form-select" style="width:100%; padding:5px; box-sizing:border-box;">
+                        <option value="">Loading nearby images...</option>
+                    </select>
+                </div>
+
+                <div style="display:flex; gap:10px; justify-content:flex-end;">
+                    <button class="btn btn-sm btn-secondary" id="edit-feat-cancel-btn-${uniq}">Cancel</button>
+                    <button class="btn btn-sm btn-success" id="edit-feat-save-btn-${uniq}">Save</button>
+                </div>
+            </div>
+        `;
+
+        marker.bindPopup(initialPopupContent);
+
+        marker.on('popupopen', async function() {
+            const imgWrapper = document.getElementById(`edit-feat-selected-img-wrapper-${uniq}`);
+            const imgEl = document.getElementById(`edit-feat-selected-img-${uniq}`);
+            const unassignBtn = document.getElementById(`edit-feat-unassign-btn-${uniq}`);
+
+            let currentGridimageId = feat.gridimage_id;
+
+            function updateAssignedImageDisplay() {
+                if (currentGridimageId && currentGridimageId > 0) {
+                    imgWrapper.style.display = 'block';
+                    if (feat.gridimage_hash) {
+                        imgEl.src = getGeographUrl(currentGridimageId, feat.gridimage_hash, 'med');
+                    } else {
+                        imgEl.src = `https://www.geograph.org.uk/photo/${currentGridimageId}`;
+                    }
+                } else {
+                    imgWrapper.style.display = 'none';
+                    imgEl.src = '';
+                }
+            }
+
+            updateAssignedImageDisplay();
+
+            if (unassignBtn) {
+                unassignBtn.addEventListener('click', function() {
+                    currentGridimageId = null;
+                    updateAssignedImageDisplay();
+                    const selectEl = document.getElementById(`edit-feat-image-select-${uniq}`);
+                    if (selectEl) {
+                        selectEl.value = "";
+                    }
+                });
+            }
+
+            // Fetch nearby curated images within 1km
+            let nearbyImages = [];
+            try {
+                const res = await fetch(`${API_BASE}?action=get_nearby_curated_images&label=${encodeURIComponent(CURRENT_LABEL)}&lat=${feat.lat}&lng=${feat.lng}`);
+                const data = await res.json();
+                nearbyImages = data.images || [];
+            } catch (err) {
+                console.error('Error fetching nearby curated images', err);
+            }
+
+            // Populate select dropdown
+            const selectEl = document.getElementById(`edit-feat-image-select-${uniq}`);
+            if (selectEl) {
+                let optionsHtml = '<option value="">-- No Image Selected --</option>';
+                nearbyImages.forEach(img => {
+                    const isSelected = img.id === currentGridimageId ? 'selected' : '';
+                    optionsHtml += `<option value="${img.id}" ${isSelected}>${escapeHtml(img.title)} (ID: ${img.id}, Dist: ${Math.round(img.dist)}m)</option>`;
+                });
+                selectEl.innerHTML = optionsHtml;
+
+                selectEl.addEventListener('change', function() {
+                    const selectedVal = this.value;
+                    if (selectedVal) {
+                        currentGridimageId = parseInt(selectedVal);
+                        const selectedImg = nearbyImages.find(img => img.id === currentGridimageId);
+                        if (selectedImg) {
+                            feat.gridimage_hash = selectedImg.hash;
+                        }
+                    } else {
+                        currentGridimageId = null;
+                    }
+                    updateAssignedImageDisplay();
+                });
+            }
+
+            // Cancel Button
+            const cancelBtn = document.getElementById(`edit-feat-cancel-btn-${uniq}`);
+            if (cancelBtn) {
+                cancelBtn.addEventListener('click', function() {
+                    marker.closePopup();
+                });
+            }
+
+            // Save Button
+            const saveBtn = document.getElementById(`edit-feat-save-btn-${uniq}`);
+            if (saveBtn) {
+                saveBtn.addEventListener('click', async function() {
+                    const newName = document.getElementById(`edit-feat-name-${uniq}`).value.trim();
+
+                    const formData = new FormData();
+                    formData.append('action', 'update_feature');
+                    formData.append('label', CURRENT_LABEL);
+                    formData.append('feature_item_id', feat.id);
+                    formData.append('name', newName);
+                    formData.append('gridimage_id', currentGridimageId !== null ? currentGridimageId : 'null');
+
+                    try {
+                        const res = await fetch(API_BASE, {
+                            method: 'POST',
+                            body: formData
+                        });
+                        const data = await res.json();
+                        if (data.error) {
+                            alert(data.error);
+                        } else {
+                            feat.name = newName;
+                            feat.gridimage_id = currentGridimageId;
+                            if (currentGridimageId) {
+                                const selectedImg = nearbyImages.find(img => img.id === currentGridimageId);
+                                if (selectedImg) {
+                                    feat.gridimage_hash = selectedImg.hash;
+                                    feat.gridimage_title = selectedImg.title;
+                                }
+                            } else {
+                                feat.gridimage_hash = null;
+                                feat.gridimage_title = null;
+                            }
+                            marker.closePopup();
+                            bindFeatureEditPopup(marker, feat);
+                        }
+                    } catch (err) {
+                        console.error('Error updating feature', err);
+                        alert('An error occurred while saving the feature.');
+                    }
+                });
+            }
+        });
     }
 
     function renderMapMarkers() {
@@ -992,6 +1291,90 @@ setTimeout(function() {
 
                     markerLayerGroup.addLayer(marker);
                     bounds.extend([item.lat, item.lng]);
+                    markerCount++;
+                }
+            });
+        }
+
+        // 4. Plot Known Features (Default Pins, Blue/standard)
+        const showFeatures = el.mapShowFeatures ? el.mapShowFeatures.checked : true;
+        if (window.FEATURE_TYPE_ID && showFeatures) {
+            state.knownFeatures.forEach(feat => {
+                if (feat.lat && feat.lng) {
+                    // Use the default Leaflet pin by NOT passing custom divIcon/icon
+                    const marker = L.marker([feat.lat, feat.lng], {
+                        draggable: true
+                    });
+
+                    let originalLatLng = L.latLng(feat.lat, feat.lng);
+
+                    marker.on('dragend', function(e) {
+                        const newLatLng = marker.getLatLng();
+
+                        const confirmPopupContent = `
+                            <div class="confirm-move-popup" style="min-width: 200px;">
+                                <h5 style="margin: 0 0 10px 0;">Move Known Feature?</h5>
+                                <p style="font-size: 13px; margin: 0 0 12px 0;">Do you want to move <b>${escapeHtml(feat.name || '[Unnamed]')}</b> to this new location?</p>
+                                <div style="display:flex; gap:10px; justify-content:flex-end;">
+                                    <button class="btn btn-sm btn-secondary" id="btn-cancel-move-${feat.id}">Cancel</button>
+                                    <button class="btn btn-sm btn-primary" id="btn-confirm-move-${feat.id}">Save Location</button>
+                                </div>
+                            </div>
+                        `;
+
+                        marker.bindPopup(confirmPopupContent).openPopup();
+
+                        setTimeout(() => {
+                            const btnCancel = document.getElementById(`btn-cancel-move-${feat.id}`);
+                            const btnConfirm = document.getElementById(`btn-confirm-move-${feat.id}`);
+
+                            if (btnCancel) {
+                                btnCancel.addEventListener('click', function() {
+                                    marker.setLatLng(originalLatLng);
+                                    marker.closePopup();
+                                    bindFeatureEditPopup(marker, feat);
+                                });
+                            }
+
+                            if (btnConfirm) {
+                                btnConfirm.addEventListener('click', async function() {
+                                    const formData = new FormData();
+                                    formData.append('action', 'update_feature_coords');
+                                    formData.append('label', CURRENT_LABEL);
+                                    formData.append('feature_item_id', feat.id);
+                                    formData.append('wgs84_lat', newLatLng.lat);
+                                    formData.append('wgs84_long', newLatLng.lng);
+
+                                    try {
+                                        const res = await fetch(API_BASE, {
+                                            method: 'POST',
+                                            body: formData
+                                        });
+                                        const data = await res.json();
+                                        if (data.error) {
+                                            alert(data.error);
+                                            marker.setLatLng(originalLatLng);
+                                        } else {
+                                            originalLatLng = newLatLng;
+                                            feat.lat = newLatLng.lat;
+                                            feat.lng = newLatLng.lng;
+                                            bindFeatureEditPopup(marker, feat);
+                                            marker.closePopup();
+                                        }
+                                    } catch (err) {
+                                        console.error('Error updating feature coords', err);
+                                        alert('An error occurred while moving the feature.');
+                                        marker.setLatLng(originalLatLng);
+                                    }
+                                });
+                            }
+                        }, 50);
+                    });
+
+                    bindFeatureEditPopup(marker, feat);
+
+                    markerLayerGroup.addLayer(marker);
+                    bounds.extend([feat.lat, feat.lng]);
                     markerCount++;
                 }
             });
@@ -1182,6 +1565,9 @@ setTimeout(function() {
     // Initial Workstation Load
     (async function init() {
         await fetchCurationState();
+        if (window.FEATURE_TYPE_ID) {
+            await fetchKnownFeatures();
+        }
         renderAllViews();
         // Run default search on active label on startup
         performRawSearch();

--- a/public_html/curated/editor/main.php
+++ b/public_html/curated/editor/main.php
@@ -11,6 +11,7 @@ $USER->mustHavePerm("basic");
 customNoCacheHeader();
 
 $label = $_GET['label'] ?? 'Sea Arches';
+$feature_type_id = isset($_GET['feature_type_id']) ? intval($_GET['feature_type_id']) : null;
 
 $smarty->display('_std_begin.tpl');
 ?>
@@ -84,6 +85,7 @@ $smarty->display('_std_begin.tpl');
                     <label><input type="checkbox" id="map-show-shortlisted" checked> Show Shortlisted (Yellow)</label>
                     <label><input type="checkbox" id="map-show-confirmed" checked> Show Confirmed (Green)</label>
                     <label id="map-live-update-container" style="color: var(--accent-color); font-weight: bold;"><input type="checkbox" id="map-live-update"> Live Update (Load More as zoom)</label>
+                    <label id="map-show-features-container" style="display:none;"><input type="checkbox" id="map-show-features" checked> Show Known Features (Pins)</label>
                 </div>
                 <div style="display: flex; align-items: center; gap: 15px;">
                     <button class="btn btn-secondary btn-sm" id="map-fit-bounds-btn">Show All (Fit to Markers)</button>
@@ -152,6 +154,7 @@ $smarty->display('_std_begin.tpl');
 <!-- Inline variables declaration -->
 <script>
     window.CURRENT_LABEL = <?php echo json_encode($label); ?>;
+    window.FEATURE_TYPE_ID = <?php echo json_encode($feature_type_id); ?>;
 </script>
 
 <!-- Curation App scripts -->

--- a/public_html/curated/editor/styles.css
+++ b/public_html/curated/editor/styles.css
@@ -442,3 +442,22 @@ body.dark-mode, body.dark-theme {
 .text-center {
     text-align: center;
 }
+
+/* Custom styles for known feature popups */
+.form-control, .form-select {
+    display: block;
+    width: 100%;
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--text-color);
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.add-feature-popup, .edit-feature-popup, .confirm-move-popup {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    color: var(--text-color);
+}


### PR DESCRIPTION
This feature expands the spatial curation workbench (public_html/curated/editor/) by introducing a toggleable and interactive known features layer. When a feature_type_id parameter is passed, the map fetches feature_items from the database and plots them as default Leaflet pins. Curators can add new features by clicking the map, move existing ones by dragging (with a confirmation step), and edit names or select/unassign curated images from a nearby dropdown (1km limit). Distance-based suggestions are also merged from feature_item into the curation sidebar.

---
*PR created automatically by Jules for task [10210624696562372714](https://jules.google.com/task/10210624696562372714) started by @barryhunter*